### PR TITLE
Fix spelling mistake on line 111

### DIFF
--- a/iso/packages.x86_64
+++ b/iso/packages.x86_64
@@ -108,7 +108,7 @@ xorg-xkill
 xorg-xrandr
 xorg-xrdb
 
-##-------- Toupad and Mouse --------##
+##-------- Touchpad and Mouse --------##
 xorg-xinput
 xf86-input-libinput
 #xf86-input-synaptics


### PR DESCRIPTION
Change from "Toupad and Mouse" to "Touchpad and Mouse"

![Capture](https://user-images.githubusercontent.com/54385073/101723454-07acd600-3af8-11eb-8adb-72ce24333291.JPG)
