### PR TITLE
Experience Update: Add CJK fonts and network proxy tools, fix zoom dark screen problem.

### DIFF
--- a/iso/airootfs/etc/skel/.config/bspwm/compton.conf
+++ b/iso/airootfs/etc/skel/.config/bspwm/compton.conf
@@ -92,6 +92,7 @@ shadow-exclude = [
     "name *= 'VLC'",
     "name *= 'Chromium'",
     "name *= 'Chrome'",
+    "! name ~= 'Zoom'",
     "class_g = 'Conky'",
     "class_g = 'Plank'",
     "class_g = 'Kupfer'",

--- a/iso/packages.x86_64
+++ b/iso/packages.x86_64
@@ -61,6 +61,7 @@ ndisc6
 nfs-utils
 nilfs-utils
 nmap
+noto-fonts-cjk #this font package is big, should be optional to user
 ntfs-3g
 nvme-cli
 ntp

--- a/iso/packages.x86_64
+++ b/iso/packages.x86_64
@@ -79,6 +79,7 @@ rp-pppoe
 rsync
 rxvt-unicode-terminfo
 sdparm
+shadowsocks # a useful network proxy tool, neccessary for users in chinese mainland.
 sg3_utils
 smartmontools
 sudo
@@ -92,6 +93,7 @@ usb_modeswitch
 usbutils
 vim
 vpnc
+v2ray # a useful network proxy tool, neccessary for users in chinese mainland.
 wireless-regdb
 wireless_tools
 wpa_supplicant


### PR DESCRIPTION
Adjust compton.conf in bspwm to avoid dark screen problem in screen sharing.
Add noto-fonts-cjk package working well with default noto fonts. However this package is too large, how to make it optional?
Add network proxy tools necessary for users inside PRC's GFW.