### PR TITLE
Fix a typo on archcraftiso-x86_64-linux.conf

### DIFF
--- a/iso/efiboot/loader/entries/archcraftiso-x86_64-linux.conf
+++ b/iso/efiboot/loader/entries/archcraftiso-x86_64-linux.conf
@@ -1,7 +1,7 @@
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-title   Boot Archcraft (64bit, UEIF)
+title   Boot Archcraft (64bit, UEFI)
 linux   /%INSTALL_DIR%/boot/x86_64/vmlinuz-linux
 initrd  /%INSTALL_DIR%/boot/intel-ucode.img
 initrd  /%INSTALL_DIR%/boot/amd-ucode.img


### PR DESCRIPTION
A pull request to fix a one-word-typographical-error.