### PR TITLE
remove termite-terminfo

### DIFF
--- a/iso/packages.x86_64
+++ b/iso/packages.x86_64
@@ -101,7 +101,6 @@ syslinux
 systemd-resolvconf
 tcpdump
 terminus-font
-termite-terminfo
 testdisk
 tmux
 tpm2-tss


### PR DESCRIPTION
Termite has been deprecated so let's remove it's terminfo which currently errors anyway. Alacritty, its self-proclaimed successor, is already included and its terminfo should suffice