### PR TITLE
Set default shell for new created users to zsh

### DIFF
--- a/airootfs/etc/default/useradd
+++ b/airootfs/etc/default/useradd
@@ -1,0 +1,1 @@
+SHELL=/bin/zsh


### PR DESCRIPTION
# Description

Sets the default shell for new created users to zsh (#205)

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## User Impact

When a new user is created, the default shell will be set from bash (default) to zsh

## Performance Impact

None

# How Has This Been Tested?

Built the iso, ran it in a vm and created a new user

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
