### PR TITLE
Replace yay with paru

### DIFF
--- a/packages.x86_64
+++ b/packages.x86_64
@@ -350,9 +350,9 @@ ksuperkey
 light
 networkmanager-dmenu-git
 obmenu-generator
+paru
 perl-linux-desktopfiles
 picom-ibhagwan-git
 polybar
 timeshift
 xfce-polkit
-yay


### PR DESCRIPTION
Yay is outdated, we should use paru. 
I just replaced yay with paru in packages file.
